### PR TITLE
Collections import compatibility fix for Python versions 3.8+

### DIFF
--- a/ipapy/ipastring.py
+++ b/ipapy/ipastring.py
@@ -7,8 +7,11 @@ ipapy contains data and functions to work with IPA strings.
 
 from __future__ import absolute_import
 from __future__ import print_function
-from collections import MutableSequence
-
+import sys
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import MutableSequence
+else:
+    from collections import MutableSequence
 from ipapy import UNICODE_TO_IPA
 from ipapy import is_valid_ipa
 from ipapy import remove_invalid_ipa_characters

--- a/ipapy/mapper.py
+++ b/ipapy/mapper.py
@@ -7,8 +7,11 @@ ipapy contains data and functions to work with IPA strings.
 
 from __future__ import absolute_import
 from __future__ import print_function
-from collections import MutableMapping
-
+import sys
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 from ipapy import split_using_dictionary
 from ipapy.compatibility import is_unicode_string
 from ipapy.data import load_data_file


### PR DESCRIPTION
In Python 3.7, importing ABCs directly from the collections module shows a
 warning and the import is deprecated since Python 3.8+

See:
https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320

Pull request added different compatible import methods per Python version.

Changes for `ipapy/ipastring.py`
```diff
-from collections import MutableSequence
import sys
if sys.version_info[:2] >= (3, 8):
    from collections.abc import MutableSequence
else:
    from collections import MutableSequence
```

Changes for `ipapy/mapper.py`
```diff
-from collections import MutableMapping
import sys
if sys.version_info[:2] >= (3, 8):
    from collections.abc import MutableMapping
else:
    from collections import MutableMapping
```